### PR TITLE
Refactor: tailwindcss 의 기본 테마 색상 설정

### DIFF
--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -7,12 +7,12 @@ export default {
   theme: {
     extend: {
       colors:{
-        BASIC_BLACK: '#161616',
-        BASIC_WHITE: '#ffff',
-        BASIC_GRAY: '#A09F9F',
-        POINT_COLOR: '#8580E1',
-        HOVER_COLOR: '#6A66B4',
-        ITEM_TITLE: '#474646'
+        BASIC_PURPLE: '#8580E1',
+        BASIC_PINK: '#FFD9E0',
+        BASIC_GRAY: '#999999',
+        BASIC_LINE: '#EEEEEE',
+        BASIC_BORDER: '#737A81',
+        BASIC_TEXT: '#555555'
       }
     },
   },


### PR DESCRIPTION
# 개요 
TailwindCSS의 기본 테마 색상 설정을 수정한 PR 입니다. 


# 작업 사항 
![스크린샷 2023-08-22 오후 4 14 32](https://github.com/HyoJeong-Park/portfolly_ver2/assets/110151638/36f71d30-1cf1-4959-b250-07027c3b72ba)

- BASIC_PURPLE / BASIC_PINK / BASIC_GRAY : 포인트 되는 색상들입니다. 
- BASIC_LINE / BASIC_BORDER :  칸이나 구분 선 박스 보더에 적용되는 색상입니다. 
- BASIC_TEXT :  기본 글자 색 적용 색상입니다. 