### PR TITLE
Refactor: 카테고리 Ui 수정 및 포트폴리오 랭킹 추가

### DIFF
--- a/client/src/assets/data/category.ts
+++ b/client/src/assets/data/category.ts
@@ -1,13 +1,13 @@
 import { CategoryTags } from '@/types';
 
-export const categories: Array<string> = ["웹", "앱", "3D/애니메이션", "그래픽디자인", "사진/영상"];
+export const categories: Array<string> = ["웹", "앱", "3D", "그래픽", "사진"];
 
 export const catagoryMapper: any = {
   "web": "웹",
   "app": "앱",
-  "3danimation": "3D/애니메이션",
-  "graphicdesign": "그래픽디자인",
-  "photo": "사진/영상",
+  "3danimation": "3D",
+  "graphicdesign": "그래픽",
+  "photo": "사진",
 };
 
 export const categoryTags: CategoryTags = {

--- a/client/src/commons/atoms/buttons/category/CategoryButton.tsx
+++ b/client/src/commons/atoms/buttons/category/CategoryButton.tsx
@@ -48,9 +48,14 @@ export interface CategoryBtnProps {
 
 // style3;
 const Category = styled.button`
-  ${tw`h-12 px-10 text-base font-semibold text-gray-400 uppercase tracking-wider border border-transparent rounded-md bg-transparent focus:outline-none transition-all duration-300 ease-in-out transform active:scale-95`}
-  &:hover, &:focus {
-    color: white;
+  ${tw`h-12 pr-20 text-xl font-semibold text-gray-400 uppercase tracking-wider border border-transparent rounded-md bg-transparent focus:outline-none transition-all duration-300 ease-in-out transform active:scale-95`}
+  &:focus {
+    ${tw`
+      text-BASIC_PURPLE
+      underline
+      underline-offset-4
+      decoration-BASIC_PURPLE
+    `}
   }
 `;
 

--- a/client/src/commons/styles/Containers.styled.tsx
+++ b/client/src/commons/styles/Containers.styled.tsx
@@ -13,7 +13,7 @@ export const Center = tw.div`
 `;
 
 export const FlexContainer = tw(Container)`
-  items-center justify-center mt-10
+  items-center justify-center
 `;
 //categorypart 같음
 export const FlexColumnContainer = tw(Container)`

--- a/client/src/commons/styles/layout/Layout.styled.tsx
+++ b/client/src/commons/styles/layout/Layout.styled.tsx
@@ -21,7 +21,7 @@ const BackgroundImage = styled.div`
   ${tw`
     absolute top-0 left-0 w-full h-full bg-center bg-no-repeat bg-cover
   `}
-  background-image: url(${defaultBgimg});
+  // background-image: url(${defaultBgimg});
   pointer-events: none;
 `;
 

--- a/client/src/components/portfolioLanking/PortfolioLanking.styled.tsx
+++ b/client/src/components/portfolioLanking/PortfolioLanking.styled.tsx
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+import tw from 'twin.macro';
+
+export const PortfolioLankingWrapper = styled.div`
+  
+  height: 400px;
+  background-color: rgb(255, 192, 203, 0.1);
+  h1 {
+    padding: 10px 100px;
+    font-size: 2.5rem;
+  }
+`;
+
+export const ProlfolioLankingItemWrapper = styled.div`
+  ${tw`
+  flex
+  items-center
+  justify-around
+  `}
+`;
+
+export const PortfolioLankingItem = styled.div`
+  width: 100%;
+  height: 300px;
+  background-color: gray;
+  margin: 0 30px;
+  border-radius: 20px;
+  padding: 10px;
+  display: inline-block;
+  
+`;

--- a/client/src/components/portfolioLanking/PortfolioLanking.tsx
+++ b/client/src/components/portfolioLanking/PortfolioLanking.tsx
@@ -1,0 +1,17 @@
+import { PortfolioLankingWrapper,ProlfolioLankingItemWrapper, PortfolioLankingItem } from './PortfolioLanking.styled';
+
+export default function PortfolioLanking() {
+
+  return (
+    <>
+    <PortfolioLankingWrapper>
+      <h1>TOP</h1>
+      <ProlfolioLankingItemWrapper>
+        <PortfolioLankingItem>냐호</PortfolioLankingItem>
+        <PortfolioLankingItem>호야</PortfolioLankingItem>
+        <PortfolioLankingItem>호엥</PortfolioLankingItem>
+      </ProlfolioLankingItemWrapper>
+    </PortfolioLankingWrapper>
+    </>
+  );
+};

--- a/client/src/pages/landingpage/LandingPage.tsx
+++ b/client/src/pages/landingpage/LandingPage.tsx
@@ -1,82 +1,24 @@
-// import styled, { keyframes } from 'styled-components';
-// import { useEffect, useState } from 'react';
-// import AOS from 'aos';
-// import 'aos/dist/aos.css';
+import { Link } from 'react-router-dom';
+
 import PortfolioSection from '@/components/home-section/portfolio-section/PortfolioSection';
 import CommunitySection from '@/components/home-section/community-section/CommunitySection';
-// import AnimationSection from '@/components/home-section/animation-section/AnimationSection';
-// import GraphicDesignSection from '@/components/home-section/graphic-section/GraphicDesignSection';
-// import PhotographySection from '@/components/home-section/photography-section/PhotographySection';
-// import DisplaySection from '@/components/home-section/display-section/DisplaySection';
-import { HomeWrapper, HomeContentsWrapper } from './LandingPage.styled';
-// import SkipButton from '@/commons/atoms/buttons/skip/SkipButton';
 import Header from '@/components/header/Header';
+
+import { HomeWrapper, HomeContentsWrapper } from './LandingPage.styled';
 
 
 export default function LandingPage() {
-  // const [animationComplete, setAnimationComplete] = useState(false);
-  // const [showScrollHint, setShowScrollHint] = useState(true);
-
-  // useEffect(() => {
-  //   const handleAnimationEnd = () => {
-  //     setAnimationComplete(true);
-  //   };
-
-  //   const textElement = document.getElementById('portfolly-text');
-  //   if (textElement) {
-  //     textElement.addEventListener('animationend', handleAnimationEnd);
-
-  //     return () => {
-  //       textElement.removeEventListener('animationend', handleAnimationEnd);
-  //     };
-  //   }
-  // }, []);
-
-  // useEffect(() => {
-  //   const handleScroll = () => {
-  //     setShowScrollHint(false);
-  //   };
-
-  //   window.addEventListener('scroll', handleScroll);
-
-  //   return () => {
-  //     window.removeEventListener('scroll', handleScroll);
-  //   };
-  // }, []);
-
-  // useEffect(() => {
-  //   AOS.init({
-  //     offset: 200,
-  //     duration: 800,
-  //     easing: 'ease-in-out',
-  //     delay: 300,
-  //   });
-  // }, []);
 
   return (
     <HomeWrapper>
-      {/* <FullPageContainer>
-        <PortfollyText id="portfolly-text">Portfolly</PortfollyText>
-      </FullPageContainer>
-      
-      {animationComplete && (
-        <>
-          
-          {animationComplete && showScrollHint && 
-            <ScrollDownIndicator>&#8595;</ScrollDownIndicator>
-          }
-          <AppSection />
-          <AnimationSection />
-          <GraphicDesignSection />
-          <PhotographySection />
-          <DisplaySection />
-        </>
-      )}
-      <SkipButton /> */}
       <Header />
       <HomeContentsWrapper>
-        <PortfolioSection />
-        <CommunitySection />
+        <Link to='/main'>
+          <PortfolioSection />
+        </Link>
+        <Link to='/boards'>
+          <CommunitySection />
+        </Link>
       </HomeContentsWrapper>
     </HomeWrapper>
   );

--- a/client/src/pages/main/Main.styled.tsx
+++ b/client/src/pages/main/Main.styled.tsx
@@ -1,5 +1,6 @@
 import tw from 'twin.macro';
 import styled from 'styled-components';
+import { Purpletype } from '@/commons/atoms/buttons/Button.styled';
 
 export const WebItemsContainer = styled.div`
   ${tw`
@@ -26,4 +27,52 @@ export const NodataImage = styled.img`
   width: 350px;
   height: 350px;
   margin-top: 60px;
+`;
+
+export const TitleSection = styled.div`
+  ${tw`
+    flex
+    items-center
+    justify-between
+    my-5
+  `}
+  padding: 0 100px;
+
+  h1 {
+    font-size: 2rem;
+  }
+`;
+
+export const CategorySection = styled(TitleSection)`
+  .currentPick {
+    ${tw`
+      text-BASIC_PURPLE
+    `}
+  }
+`;
+
+export const WriteButton = styled(Purpletype)`
+  ${tw`
+    text-BASIC_PURPLE
+    bg-neutral-200
+    px-5
+    py-2
+  `}
+  border-radius: 5px;
+
+  &:hover{
+    ${tw`
+      text-white
+    `}
+  }
+`
+
+export const FilterWrapper = styled.ul`
+  ${tw`
+  flex
+  items-center
+  justify-between
+  `}
+
+  width: 100px;
 `;

--- a/client/src/pages/main/Main.tsx
+++ b/client/src/pages/main/Main.tsx
@@ -1,18 +1,19 @@
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { category } from '@/store/categorySlice';
-// import { call } from '@/utils/apiService';
 
 import CategoryNavBar from '@/components/navbar/CategoryNavBar';
 import WebItem from '@/components/webItem/WebItem';
-import { WebItemsContainer, NodataImage } from './Main.styled';
+import { WebItemsContainer, NodataImage, TitleSection, CategorySection, FilterWrapper, WriteButton } from './Main.styled';
 import AppItem from '@/components/appItem/AppItem';
 import GraphicItem from '@/components/graphicItem/GraphicItem';
 import PhotoItem from '@/components/photoItem/PhotoItem';
 import ThreeDItem from '@/components/threeDitem/ThreeDITem';
 import Search from '@/components/search/Search';
+import PortfolioLanking from '@/components/portfolioLanking/PortfolioLanking';
 import datano from '@/assets/datano.png';
 import axios from 'axios';
+import { Link } from 'react-router-dom';
 
 const categoryMap = {
   web: 'web',
@@ -41,11 +42,6 @@ export default function Main() {
     window.scrollTo(0, 0);
     const fetchData = async () => {
       try {
-        // const res = await call(`/portfolios?category=${categoryParam}&page=1&size=5`, 'GET', null);
-        // console.log(res);
-        // setItems(res.data);
-        // setFilteredItems(res.data);
-
         await axios.get(`https://api.portfolly.site/portfolios?category=${categoryParam}&page=1&size=5`).then((res) => {
           console.log(res.data.data);
           setItems(res.data.data);
@@ -91,7 +87,21 @@ export default function Main() {
   return (
     <>
       <Search setSearchValue={setSearchTerm} currentSearch={searchTerm} data={items} setSearchs={setSearchs} />
-      <CategoryNavBar />
+      <PortfolioLanking />
+      <TitleSection>
+        <h1>Portfolio</h1>
+        <Link to='/portfolio/edit'>
+          <WriteButton>포트폴리오 등록</WriteButton>
+        </Link>
+      </TitleSection>
+      <CategorySection>
+        <CategoryNavBar />
+        <FilterWrapper>
+          <li className='currentPick'>최신순</li>
+          <li>|</li>
+          <li>인기순</li>
+        </FilterWrapper>
+      </CategorySection>
       <WebItemsContainer>
         {searchs.length > 0 ? (
           searchs.map((searchedItem: any, index: any) => {


### PR DESCRIPTION
## 개요
포트폴리오 메인 페이지 카테고리 버튼 Ui 수정 및 포트폴리오 랭킹 컴포넌트 추가

## 작업 상세
카테고리 버튼 focus 될 때, 흰색 컬러로 변경에서 베이직 퍼플 컬러로 변경 및 underline 추가
포트폴리오 메인페이지 상단에 배치될 랭킹 컴포넌트 구현
- 현재로선 3개의 랭킹 게시글이 올라간다 가정하여 임시로 자리배치만 시켜둠
- figma에서 작업한 결과물과 똑같이 만들기 위한 수정 작업 필요한 상태

## 미리보기
![image](https://github.com/HyoJeong-Park/portfolly_ver2/assets/124596022/f0a5df7d-45ab-43cb-a5fb-859f01aa6de7)
