### PR TITLE
Refactor: 커뮤니티 상세페이지 1차, 2차 ui 수정

### DIFF
--- a/client/src/commons/atoms/buttons/Button.styled.tsx
+++ b/client/src/commons/atoms/buttons/Button.styled.tsx
@@ -41,8 +41,9 @@ export const Edittype = styled(Purpletype)`
     bg-zinc-300
     w-20
     py-1
-    text-base
+    text-BASIC_PURPLE
     rounded-lg
+    h-full
   `}
 `;
 

--- a/client/src/commons/atoms/card/Card.tsx
+++ b/client/src/commons/atoms/card/Card.tsx
@@ -8,10 +8,11 @@ interface CardProps extends ComponentPropsWithoutRef<'div'> {
 }
 
 const CardContainer = styled.div`
-    ${tw` w-full p-5 box-border rounded-md`}
+    ${tw` w-full p-5 box-border rounded-md mb-10`}
     background-color: white;
     box-sizing: inherit;
-    box-shadow: 0 10px 24px hsla(0,0%,0%,0.05), 0 20px 48px hsla(0, 0%, 0%, 0.05), 0 1px 4px hsla(0, 0%, 0%, 0.1);
+    // box-shadow: 0 10px 24px hsla(0,0%,0%,0.05), 0 20px 48px hsla(0, 0%, 0%, 0.05), 0 1px 4px hsla(0, 0%, 0%, 0.1);
+    border: 1px solid #eee;
 `;
 
 export default function Card({ children }: CardProps) {

--- a/client/src/commons/atoms/card/Card.tsx
+++ b/client/src/commons/atoms/card/Card.tsx
@@ -8,7 +8,7 @@ interface CardProps extends ComponentPropsWithoutRef<'div'> {
 }
 
 const CardContainer = styled.div`
-    ${tw`flex flex-col w-full h-full p-5 box-border rounded-2xl`}
+    ${tw` w-full p-5 box-border rounded-md`}
     background-color: white;
     box-sizing: inherit;
     box-shadow: 0 10px 24px hsla(0,0%,0%,0.05), 0 20px 48px hsla(0, 0%, 0%, 0.05), 0 1px 4px hsla(0, 0%, 0%, 0.1);

--- a/client/src/commons/molecules/comment/Comment.styled.tsx
+++ b/client/src/commons/molecules/comment/Comment.styled.tsx
@@ -3,16 +3,18 @@ import tw from 'twin.macro';
 
 import { FlexBetweenWrapper, FlexColumnContainer } from '@/commons/styles/Containers.styled';
 
-export const CommentContainer = tw(FlexColumnContainer)`
-  w-full border-b-[1px] pb-1.5 pt-3
+export const CommentContainer = styled(FlexColumnContainer)`
+  ${tw`flex items-center rounded-sm`}
+  height: 120px;
 `
 
 export const CommentWrapper = tw(FlexBetweenWrapper)`
-  w-full
+h-full
+  
 `
 
 export const CommentInput = styled.textarea`
-  ${tw`w-full h-20 px-2 py-1 resize-none rounded-md border-[0.5px]`}
+  ${tw`w-4/5 h-full px-2 py-1 resize-none rounded-md border-[0.5px]`}
   &:focus {outline: none;}
   border-color: gray;
   font-size: 13px;

--- a/client/src/commons/molecules/comment/Comment.styled.tsx
+++ b/client/src/commons/molecules/comment/Comment.styled.tsx
@@ -16,7 +16,7 @@ h-full
 export const CommentInput = styled.textarea`
   ${tw`w-4/5 h-full px-2 py-1 resize-none rounded-md border-[0.5px]`}
   &:focus {outline: none;}
-  border-color: gray;
+  border-color: #ddd;
   font-size: 13px;
   color:black;
 `

--- a/client/src/commons/molecules/comment/CommentWriteBox.tsx
+++ b/client/src/commons/molecules/comment/CommentWriteBox.tsx
@@ -36,18 +36,18 @@ export default function CommentWriteBox({ saveComment, handleComment, isInput }:
 
   return (
     <CommentContainer gap={5}>
-      <CommentWrapper gap={0}>
+      <CommentWrapper>
         <MemberProfile
           type="comment"
           member={{ id: Number(memberInfo), name: userName, imageUrl: 'https://picsum.photos/233' }}
         />
-        <SaveBtn onClick={saveComment} />
       </CommentWrapper>
       <CommentInput
         placeholder="write your comment"
         value={isInput}
         onChange={(e: any) => handleComment(e.target.value)}
       />
+      <SaveBtn onClick={saveComment} />
     </CommentContainer>
   );
 }

--- a/client/src/commons/molecules/profile/MemberProfile.styled.tsx
+++ b/client/src/commons/molecules/profile/MemberProfile.styled.tsx
@@ -4,7 +4,10 @@ import tw from 'twin.macro';
 import { FlexColumnWrapper, FlexWrapper } from '@/commons/styles/Containers.styled';
 
 export const MemberProfileWrapper = styled(FlexWrapper)`
-  ${tw`items-center`}
+  ${tw`h-full flex-col items-center justify-between`}
+  h3 {
+    color: #aaa;
+  }
 `
 
 export const ColumnWrapper = styled(FlexColumnWrapper)``

--- a/client/src/commons/molecules/profile/MemberProfile.tsx
+++ b/client/src/commons/molecules/profile/MemberProfile.tsx
@@ -15,7 +15,7 @@ interface MemberProfile {
 
 const ImageSizes: any = {
   board: 65,
-  comment: 35,
+  comment: 70,
   portfolio: 100,
   blackboard: 65,
 };
@@ -23,7 +23,8 @@ const ImageSizes: any = {
 const MemberProfile = ({ type, member, date }: MemberProfile) => {
   const itemPic = member.imageUrl === null ? circleNoImg : member.imageUrl;
   return (
-    <MemberProfileWrapper gap={15}>
+    <MemberProfileWrapper>
+      <h3>짱구님</h3>
       <Image src={itemPic} url={`/members/${member.id}`} shape="circle" size={ImageSizes[type]} />
       {type === 'portfolio' && <Label text={member.name} type={type} url={`/members/${member.id}`} />}
       {type !== 'portfolio' && (

--- a/client/src/commons/styles/layout/CHeaderLayout.tsx
+++ b/client/src/commons/styles/layout/CHeaderLayout.tsx
@@ -1,4 +1,4 @@
-import CHeader from '../../../components/header/CHeader';
+import Header from '../../../components/header/Header';
 import Footer from '../../../components/footer/Footer';
 import { Outlet } from 'react-router-dom';
 import { BackImgControl } from './Layout.styled';
@@ -6,7 +6,7 @@ import { BackImgControl } from './Layout.styled';
 export default function CHeaderLayout() {
   return (
     <BackImgControl>
-      <CHeader />
+      <Header />
       <Outlet />
       <Footer />
     </BackImgControl>

--- a/client/src/components/comment/CommentBox.tsx
+++ b/client/src/components/comment/CommentBox.tsx
@@ -82,7 +82,7 @@ export default function CommentBox({ comments = [], handleRender }: any) {
       <Card>
         <JbWrapper>
           <FlexColumnContainer gap={0}>
-            <img src={noComment} alt="no comments" />
+            {/* <img src={noComment} alt="no comments" /> */}
           </FlexColumnContainer>
           <CommentWriteBox saveComment={saveComment} handleComment={handleComment} isInput={currentComment} />
         </JbWrapper>

--- a/client/src/components/comment/CommentBox.tsx
+++ b/client/src/components/comment/CommentBox.tsx
@@ -13,6 +13,7 @@ import CommentWriteBox from '@/commons/molecules/comment/CommentWriteBox';
 import { JbWrapper } from '@/pages/community-detail/CommunityDetail.styled';
 import noComment from '@/assets/noComment.png';
 import netaxios from '@/utils/axiosIntercept';
+import CommentList from './commentList';
 
 export default function CommentBox({ comments = [], handleRender }: any) {
   const [currentComment, setCurrentComment] = useState('');
@@ -79,15 +80,28 @@ export default function CommentBox({ comments = [], handleRender }: any) {
 
   if (amendComment.length <= 0) {
     return (
-      <Card>
-        <JbWrapper>
-          <FlexColumnContainer gap={0}>
-            {/* <img src={noComment} alt="no comments" /> */}
-          </FlexColumnContainer>
-          <CommentWriteBox saveComment={saveComment} handleComment={handleComment} isInput={currentComment} />
-        </JbWrapper>
-      </Card>
-    );
+      <>
+        <Card>
+          {/* <JbWrapper> */}
+            {/* <FlexColumnContainer gap={0}> */}
+              {/* <img src={noComment} alt="no comments" /> */}
+              {/* <div>dasasss</div> */}
+            {/* </FlexColumnContainer> */}
+            {/* <CommentWriteBox saveComment={saveComment} handleComment={handleComment} isInput={currentComment} /> */}
+          {/* </JbWrapper> */}
+          <CommentList />
+        </Card>
+        <Card>
+          <JbWrapper>
+            <FlexColumnContainer gap={0}>
+              {/* <img src={noComment} alt="no comments" /> */}
+              {/* <div>dasasss</div> */}
+            </FlexColumnContainer>
+            <CommentWriteBox saveComment={saveComment} handleComment={handleComment} isInput={currentComment} />
+          </JbWrapper>
+        </Card>
+      </>
+    );    
   }
 
   return (

--- a/client/src/components/comment/commentList.styled.tsx
+++ b/client/src/components/comment/commentList.styled.tsx
@@ -1,0 +1,34 @@
+import { styled } from 'styled-components';
+import tw from 'twin.macro';
+
+import { MemberProfileWrapper } from '@/commons/molecules/profile/MemberProfile.styled';
+
+export const CommentsListWrapper = styled.div`
+  ${tw`
+    flex
+    // justify-between
+    items-center
+  `}
+`
+
+export const CommentProfile = styled(MemberProfileWrapper)`
+  img {
+    ${tw`rounded-full`}
+    width: 80px;
+    height: 80px;
+  }
+
+  span {
+    ${tw`mt-4 pt-2`}
+    border-top: 1px solid #ccc;
+    color: #ccc;
+    font-size: 12px;
+  }
+`
+
+export const CommentContent = styled.p`
+  ${tw`
+    w-3/4
+    pl-5
+  `}
+`;

--- a/client/src/components/comment/commentList.tsx
+++ b/client/src/components/comment/commentList.tsx
@@ -1,0 +1,17 @@
+import noComment from '@/assets/noComment.png';
+
+import {} from './commentList.styled'
+import { CommentsListWrapper, CommentProfile, CommentContent } from './commentList.styled';
+
+export default function CommentList () {
+  return (
+    <CommentsListWrapper>
+      <CommentProfile>
+        <h3>맹구씨</h3>
+        <img src={noComment} alt='noComment' />
+        <span>2023.09.13</span>
+      </CommentProfile>
+      <CommentContent>그렇대요? <br /> 거 신기한 일이네</CommentContent>
+    </CommentsListWrapper>
+  )
+}

--- a/client/src/components/detailContents/DetailContents.styled.tsx
+++ b/client/src/components/detailContents/DetailContents.styled.tsx
@@ -3,14 +3,14 @@ import styled from 'styled-components';
 
 export const DetailCntContainer = styled.div`
   ${tw`
-    bg-white
     p-5
     shadow-md
     relative
   `}
 
-  height: 700px;
-  border-radius: 20px;
+  height: 500px;
+  border-radius: 10px;
+  background-color: rgb(231, 230, 251, 0.6);
 
   > h1 {
     font-size: 40px;

--- a/client/src/components/detailContents/DetailContents.tsx
+++ b/client/src/components/detailContents/DetailContents.tsx
@@ -20,10 +20,7 @@ export default function DetailContents({ data, handleDeleteModal, id, writerId, 
 
   return (
     <DetailCntContainer>
-      <h1>{data.title}</h1>
-      <hr />
       <p>{data.content}</p>
-      <hr />
       {writerId === viewerId ? (
         <EDBtnContainer>
           <PurpleBtn onClick={moveToEdit}>Edit</PurpleBtn>

--- a/client/src/components/portfolioLanking/PortfolioLanking.styled.tsx
+++ b/client/src/components/portfolioLanking/PortfolioLanking.styled.tsx
@@ -2,13 +2,11 @@ import styled from 'styled-components';
 import tw from 'twin.macro';
 
 export const PortfolioLankingWrapper = styled.div`
-  
-  height: 400px;
-  background-color: rgb(255, 192, 203, 0.1);
-  h1 {
-    padding: 10px 100px;
-    font-size: 2.5rem;
-  }
+h1 {
+  padding: 10px 100px;
+  font-size: 2.5rem;
+  font-weight: 300;
+}
 `;
 
 export const ProlfolioLankingItemWrapper = styled.div`
@@ -16,7 +14,9 @@ export const ProlfolioLankingItemWrapper = styled.div`
   flex
   items-center
   justify-around
+  py-7
   `}
+  background-color: rgb(255, 192, 203, 0.1);
 `;
 
 export const PortfolioLankingItem = styled.div`

--- a/client/src/components/portfolioLanking/PortfolioLanking.tsx
+++ b/client/src/components/portfolioLanking/PortfolioLanking.tsx
@@ -1,6 +1,49 @@
+import { useEffect } from 'react';
+import axios from 'axios';
+import { useSelector } from 'react-redux';
+import { category } from '@/store/categorySlice';
+
 import { PortfolioLankingWrapper,ProlfolioLankingItemWrapper, PortfolioLankingItem } from './PortfolioLanking.styled';
 
 export default function PortfolioLanking() {
+
+  const categoryMap = {
+    web: 'web',
+    app: 'app',
+    '3danimation': '3danimation',
+    graphicdesign: 'graphicdesign',
+    photo: 'photo',
+  };
+
+  const selectedCategory = useSelector(category);
+
+  const categoryParam = categoryMap[selectedCategory] || 'web';
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await axios.get(`https://api.portfolly.site/portfolios?category=${categoryParam}&page=1&size=5`)
+        const responseData = response.data.data;
+        const views = responseData.map((item:any) => item.view)
+
+        for(let i = 0; i<views.length; i++){
+          let arr = [];
+          if(views[i] > views[i+1]){
+            arr.push(views[i]);
+          }
+          arr.push(views[i+1]);
+
+          return console.log(arr);
+        }
+
+        console.log(views);
+      }catch (error) {
+        console.log(error);
+      }
+    }
+
+    fetchData();
+  }, []);
 
   return (
     <>

--- a/client/src/components/search/Search.styled.tsx
+++ b/client/src/components/search/Search.styled.tsx
@@ -10,7 +10,7 @@ export const SearchContainer = tw.form`
   max-w-md
   min-w-min
   mx-auto
-  text-white
+  text-BASIC_TEXT
 `;
 
 export const SearchIcon = styled(BsSearchHeart)`
@@ -18,7 +18,7 @@ export const SearchIcon = styled(BsSearchHeart)`
     absolute
     ml-4 
     top-1/2
-    text-gray-300
+    text-BASIC_TEXT
     transform -translate-y-1/2
     transition-colors duration-300 ease-in-out
   `}
@@ -28,11 +28,12 @@ export const SearchBox = styled.input`
   ${tw`
     pl-12
     h-12
-    text-white
+    text-BASIC_TEXT
     w-full
-    rounded-full	
+    rounded-md
     bg-transparent
-    border-2 border-gray-500
+    border
+    border-neutral-400
   `}
 
   &:focus {

--- a/client/src/components/search/Search.tsx
+++ b/client/src/components/search/Search.tsx
@@ -59,7 +59,7 @@ export default function Search({ setSearchValue, currentSearch, data, setSearchs
   return (
     <SearchContainer onSubmit={enterToSearch}>
       <SearchIcon />
-      <SearchBox type="text" onChange={handleChange} />
+      <SearchBox type="text" placeholder='포트폴리오 검색' onChange={handleChange} />
     </SearchContainer>
   );
 }

--- a/client/src/pages/community-detail/CommunityDetail.styled.tsx
+++ b/client/src/pages/community-detail/CommunityDetail.styled.tsx
@@ -2,8 +2,16 @@ import tw from 'twin.macro';
 import { styled } from 'styled-components'
 
 export const PageWrapper = styled.div`
-  ${tw`flex flex-col gap-8 min-h-screen bg-center bg-no-repeat bg-cover mt-10`}
+  ${tw`flex flex-col min-h-screen bg-center bg-no-repeat bg-cover mt-10`}
   padding: 0 100px;
+
+  h2 {
+    ${tw`text-xl pt-10`}
+  }
+
+  hr {
+    ${tw`pb-5`}
+  }
 `;
 
 export const TitleContainer = styled.div`
@@ -24,21 +32,17 @@ export const MainContainer = tw.div`
 `;
 
 export const CmDContainer = tw.div`
-  w-full
+  // w-full
 `;
 
 export const CommentContainer = tw.div`
-  w-full
-  h-[700px]
+  // w-full
+  // h-[700px]
 `;
 
 export const CommentWrite = tw.div`
   
 `;
 
-export const JbWrapper = tw.div`
-  flex
-  flex-col
-  justify-between
-  h-full
+export const JbWrapper = styled.div`
 `;

--- a/client/src/pages/community-detail/CommunityDetail.styled.tsx
+++ b/client/src/pages/community-detail/CommunityDetail.styled.tsx
@@ -22,6 +22,7 @@ export const TitleContainer = styled.div`
   `}
 
   h1 {
+    ${tw`pl-5`}
     font-size: 1.5rem;
   }
 `;
@@ -29,6 +30,7 @@ export const TitleContainer = styled.div`
 export const MainContainer = tw.div`
   flex
   gap-10
+  my-8
 `;
 
 export const CmDContainer = tw.div`
@@ -36,8 +38,6 @@ export const CmDContainer = tw.div`
 `;
 
 export const CommentContainer = tw.div`
-  // w-full
-  // h-[700px]
 `;
 
 export const CommentWrite = tw.div`

--- a/client/src/pages/community-detail/CommunityDetail.styled.tsx
+++ b/client/src/pages/community-detail/CommunityDetail.styled.tsx
@@ -1,9 +1,22 @@
 import tw from 'twin.macro';
 import { styled } from 'styled-components'
 
-export const PageWrapper = styled.div(( ) => [
-  tw`flex flex-col gap-8 w-full h-full min-h-screen bg-center bg-no-repeat bg-cover pt-10 px-8`,
-]);
+export const PageWrapper = styled.div`
+  ${tw`flex flex-col gap-8 min-h-screen bg-center bg-no-repeat bg-cover mt-10`}
+  padding: 0 100px;
+`;
+
+export const TitleContainer = styled.div`
+  ${tw`
+    flex
+    items-center
+    justify-start
+  `}
+
+  h1 {
+    font-size: 1.5rem;
+  }
+`;
 
 export const MainContainer = tw.div`
   flex
@@ -11,11 +24,11 @@ export const MainContainer = tw.div`
 `;
 
 export const CmDContainer = tw.div`
-  w-2/3
+  w-full
 `;
 
 export const CommentContainer = tw.div`
-  w-1/3
+  w-full
   h-[700px]
 `;
 

--- a/client/src/pages/community-detail/CommunityDetail.styled.tsx
+++ b/client/src/pages/community-detail/CommunityDetail.styled.tsx
@@ -28,8 +28,6 @@ export const TitleContainer = styled.div`
 `;
 
 export const MainContainer = tw.div`
-  flex
-  gap-10
   my-8
 `;
 

--- a/client/src/pages/community-detail/CommunityDetail.tsx
+++ b/client/src/pages/community-detail/CommunityDetail.tsx
@@ -10,7 +10,7 @@ import DeleteModal from '@/components/modal/DeleteModal';
 
 import { CommuProps } from '@/types';
 
-import { CmDContainer, CommentContainer, MainContainer, PageWrapper } from './CommunityDetail.styled';
+import { CmDContainer, CommentContainer, TitleContainer, MainContainer, PageWrapper } from './CommunityDetail.styled';
 
 export default function CommunityDetail({ handleClick }: any) {
   const [memberData, setMemberData] = useState<CommuProps | null>(null);
@@ -66,14 +66,17 @@ export default function CommunityDetail({ handleClick }: any) {
 
   return (
     <PageWrapper>
-      <MemberProfile
-        type={'blackboard'}
-        member={{
-          id: memberData.memberId,
-          name: memberData.name,
-          imageUrl: 'https://picsum.photos/200/300',
-        }}
-      />
+      <TitleContainer>
+        <MemberProfile
+          type={'blackboard'}
+          member={{
+            id: memberData.memberId,
+            name: memberData.name,
+            imageUrl: 'https://picsum.photos/200/300',
+          }}
+        />
+        <h1>{memberData.title}</h1>
+      </TitleContainer>
       <MainContainer onClick={handleClick}>
         <CmDContainer>
           <DetailContents
@@ -84,10 +87,10 @@ export default function CommunityDetail({ handleClick }: any) {
             viewerId={viewerId}
           />
         </CmDContainer>
-        <CommentContainer>
-          <CommentBox comments={memberData.comments} handleRender={handleRender} />
-        </CommentContainer>
       </MainContainer>
+      <CommentContainer>
+        <CommentBox comments={memberData.comments} handleRender={handleRender} />
+      </CommentContainer>
       {clickDeletePost ? <DeleteModal onConfirm={handleDeleteModal} onCancel={handleDeleteModal} /> : ''}
     </PageWrapper>
   );

--- a/client/src/pages/community-detail/CommunityDetail.tsx
+++ b/client/src/pages/community-detail/CommunityDetail.tsx
@@ -88,6 +88,8 @@ export default function CommunityDetail({ handleClick }: any) {
           />
         </CmDContainer>
       </MainContainer>
+      <h2>Comments</h2>
+      <hr />
       <CommentContainer>
         <CommentBox comments={memberData.comments} handleRender={handleRender} />
       </CommentContainer>

--- a/client/src/pages/main/Main.styled.tsx
+++ b/client/src/pages/main/Main.styled.tsx
@@ -34,12 +34,14 @@ export const TitleSection = styled.div`
     flex
     items-center
     justify-between
-    my-5
+    mt-10
+    mb-5
   `}
   padding: 0 100px;
 
   h1 {
     font-size: 2rem;
+    font-weight: 300;
   }
 `;
 

--- a/client/src/pages/main/Main.tsx
+++ b/client/src/pages/main/Main.tsx
@@ -86,10 +86,10 @@ export default function Main() {
 
   return (
     <>
-      <Search setSearchValue={setSearchTerm} currentSearch={searchTerm} data={items} setSearchs={setSearchs} />
       <PortfolioLanking />
       <TitleSection>
         <h1>Portfolio</h1>
+        <Search setSearchValue={setSearchTerm} currentSearch={searchTerm} data={items} setSearchs={setSearchs} />
         <Link to='/portfolio/edit'>
           <WriteButton>포트폴리오 등록</WriteButton>
         </Link>


### PR DESCRIPTION
## 개요
커뮤니티 상세페이지 1차, 2차 ui 수정

## 작업 상세
- 헤더 변경
- 본문 ui 수정
- 댓글 ui 수정 및 각 컴포넌트 재배치

## 미리보기
<img width="1032" alt="스크린샷 2023-08-28 오후 4 24 18" src="https://github.com/HyoJeong-Park/portfolly_ver2/assets/124596022/60bab4e3-f46a-4ad3-95cd-db56b461aef2">
<img width="917" alt="image" src="https://github.com/HyoJeong-Park/portfolly_ver2/assets/124596022/aa2bd96c-86d6-430c-a8fc-c9386bbfbfcf">


## 수정할 사항
댓글 등록 컴포넌트에 배경은 상대단위, 세이브 버튼은 절대 단위라 화면 조정시 깨지는 현상 발견함