### PR TITLE
Refactor: 마이페이지 포트폴리오, 게시글 관리 레이아웃 구현

### DIFF
--- a/client/src/pages/mypage-ver2/MypageVer2.styled.tsx
+++ b/client/src/pages/mypage-ver2/MypageVer2.styled.tsx
@@ -12,7 +12,7 @@ export const ProfileWrapper = styled.div`
   padding: 30px;
   border-right: 2px solid #ddd;
 
-  > img {
+  .logoIamge {
     width: 130px;
   }
 `;
@@ -91,12 +91,6 @@ export const LogoutButton = styled.button`
   transform: translate(-50%, -50%);
 `;
 
-export const ProfileManageWrapper = styled.div`
-  ${tw` p-10 `}
-  width: 900px;
-  height: 100vh;
-`;
-
 export const ManageTitle = styled.h1`
   ${tw` border-b border-BASIC_LINE pb-3`}
   font-size: 2rem;
@@ -134,7 +128,7 @@ export const MypageItemWrapper = styled.div`
   ${tw` flex flex-row justify-between flex-wrap`}
 `;
 
-export const MypageItem = styled.div`
+export const MypagePortfolioItem = styled.div`
   ${tw` rounded-md p-5 my-5 `}
   border: 1px solid #888;
   width: 250px;
@@ -164,5 +158,30 @@ export const MypageItemViews = styled.div`
 
   > span {
     ${tw` px-2 text-POINT_COLOR text-xs `}
+  }
+`;
+
+export const MypageCommunityItem = styled(MypagePortfolioItem)`
+  .mypageCommunityItemContentWrapper {
+    ${tw` flex flex-col justify-between `}
+    height: 85%;
+  }
+`;
+
+export const MypageCommunityItemContent = styled.div`
+  ${tw` flex flex-col `}
+  > h3 {
+    ${tw` text-BASIC_TEXT font-bold text-xl mb-3`}
+  }
+
+  > p {
+    ${tw` text-POINT_COLOR text-xs `}
+  }
+`;
+
+export const MypageCommunityItemTag = styled.div`
+  ${tw` bg-BASIC_PURPLE rounded-md text-BASIC_WHITE inline px-2 py-1 font-light mr-2 `}
+  > span {
+    ${tw` text-sm `}
   }
 `;

--- a/client/src/pages/mypage-ver2/MypageVer2.styled.tsx
+++ b/client/src/pages/mypage-ver2/MypageVer2.styled.tsx
@@ -7,7 +7,7 @@ export const MypageWrapper = styled.div`
 
 export const ProfileWrapper = styled.div`
   ${tw` relative `}
-  width: 450px;
+  width: 33%;
   height: 100vh;
   padding: 30px;
   border-right: 2px solid #ddd;
@@ -40,8 +40,8 @@ export const ProfileUser = styled.div`
   }
 
   .editButton {
-    ${tw` bg-BASIC_PURPLE rounded-full p-1 text-white absolute bottom-12 `}
-    right: 140px;
+    ${tw` bg-BASIC_PURPLE rounded-full p-1 text-white absolute bottom-11 `}
+    right: 150px;
     border: 2px solid #fff;
 
     &:hover {
@@ -92,14 +92,15 @@ export const LogoutButton = styled.button`
 `;
 
 export const ProfileManageWrapper = styled.div`
-  ${tw` p-10`}
-  width: 990px;
+  ${tw` p-10 `}
+  width: 900px;
   height: 100vh;
-
-  h1 {
-    font-size: 2rem;
-  }
 `;
+
+export const ManageTitle = styled.h1`
+  ${tw` border-b border-BASIC_LINE pb-3`}
+  font-size: 2rem;
+`
 
 export const IntroductionContents = styled.div`
   ${tw` rounded-lg p-8 border-BASIC_BORDER border my-10 shadow-md`}
@@ -120,5 +121,48 @@ export const IntroductionContents = styled.div`
     width: 100%;
     height: 200px;
     background-color: rgb(217,217,217,0.2);
+  }
+`;
+
+export const ManageWrapper = styled.div`
+  ${tw` p-10 `}
+  width: 65%;
+  
+`;
+
+export const MypageItemWrapper = styled.div`
+  ${tw` flex flex-row justify-between flex-wrap`}
+`;
+
+export const MypageItem = styled.div`
+  ${tw` rounded-md p-5 my-5 `}
+  border: 1px solid #888;
+  width: 250px;
+  height: 310px;
+
+  > h3 {
+    ${tw` text-BASIC_TEXT font-bold text-base mb-1`}
+  }
+
+  > p {
+    ${tw` text-POINT_COLOR text-xs `}
+  }
+`;
+
+export const MypageItemImage = styled.img`
+  ${tw` rounded-md mb-3 `}
+  width: 100%;
+  height: 160px;
+`;
+
+export const MypageItemViews = styled.div`
+  ${tw` pt-2 mt-4 border-BASIC_BORDER border-t border-solid flex items-center `}
+
+  .viewIcon path {
+    ${tw` text-BASIC_BORDER `}
+  }
+
+  > span {
+    ${tw` px-2 text-POINT_COLOR text-xs `}
   }
 `;

--- a/client/src/pages/mypage-ver2/MypageVer2.tsx
+++ b/client/src/pages/mypage-ver2/MypageVer2.tsx
@@ -13,15 +13,18 @@ import {
   RequestAlarm,
   CategoryList,
   LogoutButton,
-  ProfileManageWrapper,
   IntroductionContents,
   ManageWrapper,
-  MypageItem,
+  MypagePortfolioItem,
   MypageItemImage,
   MypageItemViews,
   ManageTitle,
   MypageItemWrapper,
+  MypageCommunityItem,
+  MypageCommunityItemContent,
+  MypageCommunityItemTag,
 } from './MypageVer2.styled';
+import { Link } from 'react-router-dom';
 
 export default function MypageVer2 () {
   const [clickedCategory, setClickedCategory] = useState('profile');
@@ -33,7 +36,9 @@ export default function MypageVer2 () {
   return (
     <MypageWrapper>
       <ProfileWrapper>
-        <img src={logoVer2} alt='logoImage' />
+        <Link to='/'>
+          <img className='logoIamge' src={logoVer2} alt='logoImage' />
+        </Link>
         <ProfileUser>
           <div className='editButton'><BsFillPencilFill size={12} /></div>
           <img src={userImage} alt='userimage' />
@@ -73,7 +78,7 @@ export default function MypageVer2 () {
             <ManageTitle>My Portfolio</ManageTitle>
             <MypageItemWrapper>
               {/* 아이템 컴포넌트로 빼기 */}
-              <MypageItem>
+              <MypagePortfolioItem>
                 <MypageItemImage src={userImage} alt='임시이미지' />
                 <h3>Web UI Design</h3>
                 <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
@@ -81,8 +86,8 @@ export default function MypageVer2 () {
                   <AiOutlineEye className='viewIcon' size={18} />
                   <span>300</span>
                 </MypageItemViews>
-              </MypageItem>
-              <MypageItem>
+              </MypagePortfolioItem>
+              <MypagePortfolioItem>
                 <MypageItemImage src={userImage} alt='임시이미지' />
                 <h3>Web UI Design</h3>
                 <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
@@ -90,8 +95,8 @@ export default function MypageVer2 () {
                   <AiOutlineEye className='viewIcon' size={18} />
                   <span>300</span>
                 </MypageItemViews>
-              </MypageItem>
-              <MypageItem>
+              </MypagePortfolioItem>
+              <MypagePortfolioItem>
                 <MypageItemImage src={userImage} alt='임시이미지' />
                 <h3>Web UI Design</h3>
                 <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
@@ -99,8 +104,8 @@ export default function MypageVer2 () {
                   <AiOutlineEye className='viewIcon' size={18} />
                   <span>300</span>
                 </MypageItemViews>
-              </MypageItem>
-              <MypageItem>
+              </MypagePortfolioItem>
+              <MypagePortfolioItem>
                 <MypageItemImage src={userImage} alt='임시이미지' />
                 <h3>Web UI Design</h3>
                 <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
@@ -108,7 +113,67 @@ export default function MypageVer2 () {
                   <AiOutlineEye className='viewIcon' size={18} />
                   <span>300</span>
                 </MypageItemViews>
-              </MypageItem>
+              </MypagePortfolioItem>
+            </MypageItemWrapper>
+          </ManageWrapper>
+        : (clickedCategory === 'bookmark') ?
+          <ManageWrapper>
+            <ManageTitle>My Bookmark</ManageTitle>
+            <MypageItemWrapper>
+              {/* 아이템 컴포넌트로 빼기 */}
+              <MypagePortfolioItem>
+                <MypageItemImage src={userImage} alt='임시이미지' />
+                <h3>Web UI Design</h3>
+                <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
+                <MypageItemViews>
+                  <AiOutlineEye className='viewIcon' size={18} />
+                  <span>300</span>
+                </MypageItemViews>
+              </MypagePortfolioItem>
+              <MypagePortfolioItem>
+                <MypageItemImage src={userImage} alt='임시이미지' />
+                <h3>Web UI Design</h3>
+                <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
+                <MypageItemViews>
+                  <AiOutlineEye className='viewIcon' size={18} />
+                  <span>300</span>
+                </MypageItemViews>
+              </MypagePortfolioItem>
+              <MypagePortfolioItem>
+                <MypageItemImage src={userImage} alt='임시이미지' />
+                <h3>Web UI Design</h3>
+                <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
+                <MypageItemViews>
+                  <AiOutlineEye className='viewIcon' size={18} />
+                  <span>300</span>
+                </MypageItemViews>
+              </MypagePortfolioItem>
+            </MypageItemWrapper>
+          </ManageWrapper>
+        : (clickedCategory === 'article') ?
+          <ManageWrapper>
+            <ManageTitle>Community</ManageTitle>
+            <MypageItemWrapper>
+              <MypageCommunityItem>
+                <div className='mypageCommunityItemContentWrapper'>
+                  <MypageCommunityItemContent>
+                    <h3>Web UI Design</h3>
+                    <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
+                  </MypageCommunityItemContent>
+                  <div className='mypageCommunityItemTagWrapper'>
+                    <MypageCommunityItemTag>
+                      <span>#React</span>
+                    </MypageCommunityItemTag>
+                    <MypageCommunityItemTag>
+                      <span>#Typescript</span>
+                    </MypageCommunityItemTag>
+                  </div>
+                </div>
+                <MypageItemViews>
+                  <AiOutlineEye className='viewIcon' size={18} />
+                  <span>300</span>
+                </MypageItemViews>
+              </MypageCommunityItem>       
             </MypageItemWrapper>
           </ManageWrapper>
         : ''

--- a/client/src/pages/mypage-ver2/MypageVer2.tsx
+++ b/client/src/pages/mypage-ver2/MypageVer2.tsx
@@ -4,6 +4,7 @@ import logoVer2 from '@/assets/logoVer2.png';
 import userImage from '@/assets/userImg.jpg';
 import { BiBell } from 'react-icons/bi';
 import { BsFillPencilFill } from 'react-icons/bs';
+import { AiOutlineEye } from 'react-icons/ai';
 
 import {
   MypageWrapper,
@@ -14,6 +15,12 @@ import {
   LogoutButton,
   ProfileManageWrapper,
   IntroductionContents,
+  ManageWrapper,
+  MypageItem,
+  MypageItemImage,
+  MypageItemViews,
+  ManageTitle,
+  MypageItemWrapper,
 } from './MypageVer2.styled';
 
 export default function MypageVer2 () {
@@ -45,9 +52,9 @@ export default function MypageVer2 () {
         </CategoryList>
         <LogoutButton>로그아웃</LogoutButton>
       </ProfileWrapper>
-      {clickedCategory === 'profile' ? 
-        <ProfileManageWrapper>
-          <h1>Profile</h1>
+      {(clickedCategory === 'profile') ? 
+        <ManageWrapper>
+          <ManageTitle>Profile</ManageTitle>
           <IntroductionContents>
             <h3>기본정보</h3>
             <ul>
@@ -60,8 +67,52 @@ export default function MypageVer2 () {
             <h3>Skill</h3>
             <div className='skillList'></div>
           </IntroductionContents>
-        </ProfileManageWrapper>
-      : ''}
+        </ManageWrapper>
+      : (clickedCategory === 'portfolio') ? 
+          <ManageWrapper>
+            <ManageTitle>My Portfolio</ManageTitle>
+            <MypageItemWrapper>
+              {/* 아이템 컴포넌트로 빼기 */}
+              <MypageItem>
+                <MypageItemImage src={userImage} alt='임시이미지' />
+                <h3>Web UI Design</h3>
+                <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
+                <MypageItemViews>
+                  <AiOutlineEye className='viewIcon' size={18} />
+                  <span>300</span>
+                </MypageItemViews>
+              </MypageItem>
+              <MypageItem>
+                <MypageItemImage src={userImage} alt='임시이미지' />
+                <h3>Web UI Design</h3>
+                <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
+                <MypageItemViews>
+                  <AiOutlineEye className='viewIcon' size={18} />
+                  <span>300</span>
+                </MypageItemViews>
+              </MypageItem>
+              <MypageItem>
+                <MypageItemImage src={userImage} alt='임시이미지' />
+                <h3>Web UI Design</h3>
+                <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
+                <MypageItemViews>
+                  <AiOutlineEye className='viewIcon' size={18} />
+                  <span>300</span>
+                </MypageItemViews>
+              </MypageItem>
+              <MypageItem>
+                <MypageItemImage src={userImage} alt='임시이미지' />
+                <h3>Web UI Design</h3>
+                <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
+                <MypageItemViews>
+                  <AiOutlineEye className='viewIcon' size={18} />
+                  <span>300</span>
+                </MypageItemViews>
+              </MypageItem>
+            </MypageItemWrapper>
+          </ManageWrapper>
+        : ''
+      }
     </MypageWrapper>
   )
 };


### PR DESCRIPTION
## 개요
마이페이지 포트폴리오, 게시글 관리 레이아웃 구현

## 작업 상세
포트폴리오 관리
- 포트폴리오 컴포넌트 생성

게시글 관리
- 커뮤니티 컴포넌트 생성

두 컴포넌트의 전체 Wrapper 디자인 통일시켜서 styled-component 재사용 했습니다.
또한 관리 div 의 타이틀과 구분선을 통일하여 재사용 했습니다.

이후 컴포넌트를 따로 분리하겠습니다!

## 미리보기

![image](https://github.com/HyoJeong-Park/portfolly_ver2/assets/124596022/df2eed3f-7211-4da2-b874-81078ec68129)
![image](https://github.com/HyoJeong-Park/portfolly_ver2/assets/124596022/364584cf-2732-41b8-b389-b5fed6025c4e)
![image](https://github.com/HyoJeong-Park/portfolly_ver2/assets/124596022/aaf937f6-33ea-4a28-8b66-de03e28fb37b)

