### PR TITLE
Fix: 마이페이지 관리 영역 overflow scroll 적용

### DIFF
--- a/client/src/pages/mypage-ver2/MypageVer2.styled.tsx
+++ b/client/src/pages/mypage-ver2/MypageVer2.styled.tsx
@@ -119,13 +119,14 @@ export const IntroductionContents = styled.div`
 `;
 
 export const ManageWrapper = styled.div`
-  ${tw` p-10 `}
+  ${tw` p-10 overflow-scroll h-screen `}
   width: 65%;
   
 `;
 
 export const MypageItemWrapper = styled.div`
-  ${tw` flex flex-row justify-between flex-wrap`}
+  ${tw` flex flex-row flex-wrap `}
+  gap: 0 40px;
 `;
 
 export const MypagePortfolioItem = styled.div`
@@ -134,12 +135,15 @@ export const MypagePortfolioItem = styled.div`
   width: 250px;
   height: 310px;
 
-  > h3 {
-    ${tw` text-BASIC_TEXT font-bold text-base mb-1`}
-  }
-
-  > p {
-    ${tw` text-POINT_COLOR text-xs `}
+  .mypagePortfolioItemContent {
+    height: 85%;
+    > h3 {
+      ${tw` text-BASIC_TEXT font-bold text-base mb-1`}
+    }
+  
+    > p {
+      ${tw` text-POINT_COLOR text-xs `}
+    }
   }
 `;
 

--- a/client/src/pages/mypage-ver2/MypageVer2.tsx
+++ b/client/src/pages/mypage-ver2/MypageVer2.tsx
@@ -79,36 +79,44 @@ export default function MypageVer2 () {
             <MypageItemWrapper>
               {/* 아이템 컴포넌트로 빼기 */}
               <MypagePortfolioItem>
-                <MypageItemImage src={userImage} alt='임시이미지' />
-                <h3>Web UI Design</h3>
-                <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
+                <div className='mypagePortfolioItemContent'>
+                  <MypageItemImage src={userImage} alt='임시이미지' />
+                  <h3>Web UI Design</h3>
+                  <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
+                </div>
                 <MypageItemViews>
                   <AiOutlineEye className='viewIcon' size={18} />
                   <span>300</span>
                 </MypageItemViews>
               </MypagePortfolioItem>
               <MypagePortfolioItem>
-                <MypageItemImage src={userImage} alt='임시이미지' />
-                <h3>Web UI Design</h3>
-                <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
+                <div className='mypagePortfolioItemContent'>
+                  <MypageItemImage src={userImage} alt='임시이미지' />
+                  <h3>Web UI Design</h3>
+                  <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
+                </div>
                 <MypageItemViews>
                   <AiOutlineEye className='viewIcon' size={18} />
                   <span>300</span>
                 </MypageItemViews>
               </MypagePortfolioItem>
               <MypagePortfolioItem>
-                <MypageItemImage src={userImage} alt='임시이미지' />
-                <h3>Web UI Design</h3>
-                <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
+                <div className='mypagePortfolioItemContent'>
+                  <MypageItemImage src={userImage} alt='임시이미지' />
+                  <h3>Web UI Design</h3>
+                  <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
+                </div>
                 <MypageItemViews>
                   <AiOutlineEye className='viewIcon' size={18} />
                   <span>300</span>
                 </MypageItemViews>
               </MypagePortfolioItem>
               <MypagePortfolioItem>
-                <MypageItemImage src={userImage} alt='임시이미지' />
-                <h3>Web UI Design</h3>
-                <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
+                <div className='mypagePortfolioItemContent'>
+                  <MypageItemImage src={userImage} alt='임시이미지' />
+                  <h3>Web UI Design</h3>
+                  <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
+                </div>
                 <MypageItemViews>
                   <AiOutlineEye className='viewIcon' size={18} />
                   <span>300</span>
@@ -122,27 +130,22 @@ export default function MypageVer2 () {
             <MypageItemWrapper>
               {/* 아이템 컴포넌트로 빼기 */}
               <MypagePortfolioItem>
-                <MypageItemImage src={userImage} alt='임시이미지' />
-                <h3>Web UI Design</h3>
-                <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
+                <div className='mypagePortfolioItemContent'>
+                  <MypageItemImage src={userImage} alt='임시이미지' />
+                  <h3>Web UI Design</h3>
+                  <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
+                </div>
                 <MypageItemViews>
                   <AiOutlineEye className='viewIcon' size={18} />
                   <span>300</span>
                 </MypageItemViews>
               </MypagePortfolioItem>
               <MypagePortfolioItem>
-                <MypageItemImage src={userImage} alt='임시이미지' />
-                <h3>Web UI Design</h3>
-                <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
-                <MypageItemViews>
-                  <AiOutlineEye className='viewIcon' size={18} />
-                  <span>300</span>
-                </MypageItemViews>
-              </MypagePortfolioItem>
-              <MypagePortfolioItem>
-                <MypageItemImage src={userImage} alt='임시이미지' />
-                <h3>Web UI Design</h3>
-                <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
+                <div className='mypagePortfolioItemContent'>
+                  <MypageItemImage src={userImage} alt='임시이미지' />
+                  <h3>Web UI Design</h3>
+                  <p>Web UI Design width React x TypeScript Project HOihHOO ..</p>
+                </div>
                 <MypageItemViews>
                   <AiOutlineEye className='viewIcon' size={18} />
                   <span>300</span>


### PR DESCRIPTION
## 개요
마이페이지 관리 영역과 프로필 영역 분리되는 것 수정했습니다.

## 작업 상세
마이페이지 관리 영역에 h-screen과 overflow-scroll을 적용하여 관리 영역에만 스크롤이 적용되도록 하였습니다.

## 미리보기
<img width="1216" alt="image" src="https://github.com/HyoJeong-Park/portfolly_ver2/assets/124596022/af82040f-2859-4925-8182-b29b13f1b779">
